### PR TITLE
CBBD-306: Fixed a bug that prevented the V5 schema script from running on HSQL

### DIFF
--- a/bluebutton-data-model-rif/pom.xml
+++ b/bluebutton-data-model-rif/pom.xml
@@ -156,6 +156,12 @@
 			<artifactId>logback-classic</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<!-- In-memory database that is used in some tests to speed things up. -->
+			<groupId>org.hsqldb</groupId>
+			<artifactId>hsqldb</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/bluebutton-data-model-rif/src/main/resources/db/migration/V5__Fix_claim_line_parentClaim_widths.sql
+++ b/bluebutton-data-model-rif/src/main/resources/db/migration/V5__Fix_claim_line_parentClaim_widths.sql
@@ -6,22 +6,22 @@
  */
 
 alter table "CarrierClaimLines"
-  alter column "parentClaim" type varchar(15);
+  alter column "parentClaim" ${logic.alter-column-type} varchar(15);
 
 alter table "DMEClaimLines"
-  alter column "parentClaim" type varchar(15);
+  alter column "parentClaim" ${logic.alter-column-type} varchar(15);
 
 alter table "HHAClaimLines"
-  alter column "parentClaim" type varchar(15);
+  alter column "parentClaim" ${logic.alter-column-type} varchar(15);
 
 alter table "HospiceClaimLines"
-  alter column "parentClaim" type varchar(15);
+  alter column "parentClaim" ${logic.alter-column-type} varchar(15);
 
 alter table "InpatientClaimLines"
-  alter column "parentClaim" type varchar(15);
+  alter column "parentClaim" ${logic.alter-column-type} varchar(15);
 
 alter table "OutpatientClaimLines"
-  alter column "parentClaim" type varchar(15);
+  alter column "parentClaim" ${logic.alter-column-type} varchar(15);
 
 alter table "SNFClaimLines"
-  alter column "parentClaim" type varchar(15);
+  alter column "parentClaim" ${logic.alter-column-type} varchar(15);

--- a/bluebutton-data-model-rif/src/test/java/gov/hhs/cms/bluebutton/data/model/rif/schema/DatabaseSchemaManagerTest.java
+++ b/bluebutton-data-model-rif/src/test/java/gov/hhs/cms/bluebutton/data/model/rif/schema/DatabaseSchemaManagerTest.java
@@ -1,0 +1,22 @@
+package gov.hhs.cms.bluebutton.data.model.rif.schema;
+
+import org.hsqldb.jdbc.JDBCDataSource;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link DatabaseSchemaManager}.
+ */
+public final class DatabaseSchemaManagerTest {
+	/**
+	 * Verifies that {@link DatabaseSchemaManager} runs correctly against an
+	 * HSQL database.
+	 */
+	@Test
+	public void createOrUpdateSchemaOnHsql() {
+		JDBCDataSource hsqlDataSource = new JDBCDataSource();
+		hsqlDataSource.setUrl("jdbc:hsqldb:mem:test");
+
+		// Ensure that this runs without errors.
+		DatabaseSchemaManager.createOrUpdateSchema(hsqlDataSource);
+	}
+}


### PR DESCRIPTION
The `V5__Fix_claim_line_parentClaim_widths.sql` had an error that I didn't catch until after merging it (but before deploying it): it fails to run on HSQL. Most of our unit tests use HSQL, while most of our integration tests and our production environment uses PostgreSQL.

This fix relies on Flyway's parameter replacement within scripts. The specific replacement being used was already present and can be seen in [DatabaseSchemaManager.createScriptPlaceholdersMap(...)](https://github.com/HHSIDEAlab/bluebutton-data-model/blob/d41d213977763d2a68550c11f09ef990ea54b208/bluebutton-data-model-rif/src/main/java/gov/hhs/cms/bluebutton/data/model/rif/schema/DatabaseSchemaManager.java#L91): on HSQL it resolves to an empty string but on PostgreSQL resolves to the word "type". This works around DDL syntax differences between the two DB platforms, resolving this bug.